### PR TITLE
fix: clear framebuffer on canvas height/width change

### DIFF
--- a/Polyfills/Canvas/Source/Canvas.cpp
+++ b/Polyfills/Canvas/Source/Canvas.cpp
@@ -141,7 +141,7 @@ namespace Babylon::Polyfills::Internal
         }
     }
 
-    void NativeCanvas::UpdateRenderTarget()
+    bool NativeCanvas::UpdateRenderTarget()
     {
         // in some scenarios (eg. no size change on SetSize/SetHeight) we can re-use framebuffer
         bool needClear = m_clear;
@@ -179,7 +179,11 @@ namespace Babylon::Polyfills::Internal
 
             m_frameBufferPool.Clear();
             m_frameBufferPool.SetGraphicsContext(&m_graphicsContext);
+
+            return true;
         }
+
+        return needClear;
     }
 
     Napi::Value NativeCanvas::GetCanvasTexture(const Napi::CallbackInfo& info)

--- a/Polyfills/Canvas/Source/Canvas.h
+++ b/Polyfills/Canvas/Source/Canvas.h
@@ -66,7 +66,7 @@ namespace Babylon::Polyfills::Internal
 
         static inline std::map<std::string, std::vector<uint8_t>> fontsInfos;
 
-        void UpdateRenderTarget();
+        bool UpdateRenderTarget();
         Babylon::Graphics::FrameBuffer& GetFrameBuffer() { return *m_frameBuffer; }
         FrameBufferPool m_frameBufferPool;
 

--- a/Polyfills/Canvas/Source/Context.cpp
+++ b/Polyfills/Canvas/Source/Context.cpp
@@ -589,13 +589,17 @@ namespace Babylon::Polyfills::Internal
 
     void Context::Flush(const Napi::CallbackInfo&)
     {
-        m_canvas->UpdateRenderTarget();
+        bool needClear = m_canvas->UpdateRenderTarget();
 
         Graphics::FrameBuffer& frameBuffer = m_canvas->GetFrameBuffer();
 
         auto updateToken{m_update.GetUpdateToken()};
         bgfx::Encoder* encoder = updateToken.GetEncoder();
         frameBuffer.Bind(*encoder);
+        if (needClear)
+        {
+            frameBuffer.Clear(*encoder, BGFX_CLEAR_COLOR | BGFX_CLEAR_DEPTH | BGFX_CLEAR_STENCIL, 0, 1.f, 0);
+        }
         frameBuffer.SetViewPort(*encoder, 0.f, 0.f, 1.f, 1.f);
         const auto width = m_canvas->GetWidth();
         const auto height = m_canvas->GetHeight();


### PR DESCRIPTION
Adds back in `needClear`, which will ensure we clear framebuffer on canvas set height/width